### PR TITLE
Do not let the predicted position affect steering.

### DIFF
--- a/gdx-ai/src/com/badlogic/gdx/ai/steer/behaviors/FollowFlowField.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/steer/behaviors/FollowFlowField.java
@@ -69,9 +69,6 @@ public class FollowFlowField<T extends Vector<T>> extends SteeringBehavior<T> {
 
 	@Override
 	protected SteeringAcceleration<T> calculateRealSteering (SteeringAcceleration<T> steering) {
-		// Clear both linear and angular components
-		steering.setZero();
-
 		// Predictive or non-predictive behavior?
 		T location = (predictionTime == 0) ?
 		// Use the current position of the owner
@@ -82,6 +79,9 @@ public class FollowFlowField<T extends Vector<T>> extends SteeringBehavior<T> {
 
 		// Retrieve the flow vector at the specified location
 		T flowVector = flowField.lookup(location);
+		
+		// Clear both linear and angular components
+		steering.setZero();
 
 		if (flowVector != null && !flowVector.isZero()) {
 			Limiter actualLimiter = getActualLimiter();


### PR DESCRIPTION
While predicting, `steering.linear` is set from **current position**, leaving the agent to follow a direction away from 0,0[,0]. Especially visible when dealing with a zero `flowVector` if linear acceleration calculation is skipped. Clearing a `steering` **after** the `flowField.lookup` does the right thing, I believe.